### PR TITLE
Fix image masking on mobile Chrome browsers

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -217,10 +217,12 @@ layout: default
 
 		.feature.left.gradient img {
 			mask-image: none;
+			-webkit-mask-image: none;
 		}
 
 		.feature.right.gradient img {
 			mask-image: none;
+			-webkit-mask-image: none;
 		}
 
 		.feature.logo div {


### PR DESCRIPTION
The `mask-image` is bleeding edge, so `-webkit-mask-image` needs to be specified as well.