### PR TITLE
Fix backgrounds image changing size on macOS download

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1093,11 +1093,11 @@ section.hero {
 }
 
 section.hero .background-image {
-  width: 100%;
+  width: 150%;
   height: 100%;
   position: absolute;
   opacity: 0.6;
-  background-position: center;
+  background-position: center top;
   background-repeat: no-repeat;
   background-blend-mode: darken;
   background-size: cover;


### PR DESCRIPTION
The macOS section has more content, thus increasing the element's size holding the image. The solution is hacky for now, which is to make the image bigger and give some margin to grow vertically.